### PR TITLE
HTML docstage/doctype layout conflict fix

### DIFF
--- a/lib/isodoc/un/html/htmlstyle.scss
+++ b/lib/isodoc/un/html/htmlstyle.scss
@@ -138,7 +138,11 @@ nav {
 */
 
 .document-type-band {
-  @include docBand(2, 150, 180px);
+  @include docBand($order: 2, $offset: 180px);
+
+  .document-type {
+    top: 20px;
+  }
 }
 
 .document-stage-band {


### PR DESCRIPTION
metanorma/metanorma-ogc#128:

HTML docstage/doctype layout conflict fix,
Use new format docBand isodoc mixin