### PR TITLE
Remove `sassc` from gem runtime dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,10 @@ Encoding.default_internal = Encoding::UTF_8
 
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}" }
-
+gem 'isodoc',
+    git: 'https://github.com/metanorma/isodoc.git',
+    branch: 'feature/sassc-gem-dependecey-removal',
+    ref: '963c80b0c0c4f223fb461d159fea5a9a2e46be3f'
 gemspec
 
 if File.exist? 'Gemfile.devel'

--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,7 @@ Encoding.default_internal = Encoding::UTF_8
 
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}" }
-gem 'isodoc',
-    git: 'https://github.com/metanorma/isodoc.git',
-    branch: 'feature/sassc-gem-dependecey-removal',
-    ref: '963c80b0c0c4f223fb461d159fea5a9a2e46be3f'
+
 gemspec
 
 if File.exist? 'Gemfile.devel'

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
+require 'isodoc/gem_tasks'
 
+IsoDoc::GemTasks.install
 RSpec::Core::RakeTask.new(:spec)
 
 task :default => :spec

--- a/metanorma-unece.gemspec
+++ b/metanorma-unece.gemspec
@@ -33,9 +33,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency "iso-639"
 
   spec.add_dependency "metanorma-standoc", "~> 1.4.0"
-  spec.add_dependency "isodoc", "~> 1.1.0"
+  # spec.add_dependency "isodoc", "~> 1.1.0"
 
   spec.add_development_dependency "byebug", "~> 9.1"
+  spec.add_development_dependency "sassc", "2.4.0"
   spec.add_development_dependency "equivalent-xml", "~> 0.6"
   spec.add_development_dependency "guard", "~> 2.14"
   spec.add_development_dependency "guard-rspec", "~> 4.7"

--- a/metanorma-unece.gemspec
+++ b/metanorma-unece.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "iso-639"
 
   spec.add_dependency "metanorma-standoc", "~> 1.4.0"
-  # spec.add_dependency "isodoc", "~> 1.1.0"
+  spec.add_dependency "isodoc", "~> 1.1.0"
 
   spec.add_development_dependency "byebug", "~> 9.1"
   spec.add_development_dependency "sassc", "2.4.0"


### PR DESCRIPTION
metanorma/metanorma#109 moved sassc gem to dev dependency, temporarily added isodoc to Gemfile, added rake build script override.